### PR TITLE
feat: Add ! as command prefix in addition to an env specific command prefix

### DIFF
--- a/src/byte/bot.py
+++ b/src/byte/bot.py
@@ -26,7 +26,7 @@ load_dotenv()
 class Byte(Bot):
     """Byte Bot Base Class."""
 
-    def __init__(self, command_prefix: str, intents: Intents, activity: Activity) -> None:
+    def __init__(self, command_prefix: list[str], intents: Intents, activity: Activity) -> None:
         """Initialize the bot.
 
         Args:

--- a/src/byte/lib/settings.py
+++ b/src/byte/lib/settings.py
@@ -31,7 +31,7 @@ class DiscordSettings(BaseSettings):
 
     TOKEN: str
     """Discord API token."""
-    COMMAND_PREFIX: str = ""
+    COMMAND_PREFIX: list[str] = ["!"]
     """Command prefix for bot commands."""
     DEV_GUILD_ID: int
     """Discord Guild ID for development."""
@@ -45,11 +45,11 @@ class DiscordSettings(BaseSettings):
 
     @field_validator("COMMAND_PREFIX")
     @classmethod
-    def assemble_command_prefix(cls, value: str) -> str:  # noqa: ARG003
+    def assemble_command_prefix(cls, value: str) -> list[str]:
         """Assembles the bot command prefix based on the environment.
 
         Args:
-            value: Not used.
+            value: Default value of ``COMMAND_PREFIX``. Currently ``["!"]``
 
         Returns:
             The assembled prefix string.
@@ -57,10 +57,12 @@ class DiscordSettings(BaseSettings):
         env_urls = {
             "prod": "byte ",
             "test": "bit ",
-            "dev": "bit ",
+            "dev": "nibble ",
         }
         environment = os.getenv("ENVIRONMENT", "dev")
-        return os.getenv("COMMAND_PREFIX", env_urls[environment])
+        # Add env specific command prefix in addition to the default "!"
+        value.append(os.getenv("COMMAND_PREFIX", env_urls[environment]))
+        return value
 
     @field_validator("PRESENCE_URL")
     @classmethod


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Bytes's contribution guidelines](https://github.com/JacobCoffee/byte/blob/main/CONTRIBUTING.rst)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- Add ! as command prefix in addition to an env specific command prefix. This enables users to do things like `!ping` and `nibble ping`

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
