### PR TITLE
fix(commands): Resolve hybrid commands not displaying slash commands

### DIFF
--- a/src/byte/bot.py
+++ b/src/byte/bot.py
@@ -38,10 +38,11 @@ class Byte(Bot):
 
     async def setup_hook(self) -> None:
         """Any setup we need can be here."""
+        # Load cogs before syncing the tree.
+        await self.load_cogs()
         dev_guild = discord.Object(id=settings.discord.DEV_GUILD_ID)
         self.tree.copy_global_to(guild=dev_guild)
         await self.tree.sync(guild=dev_guild)
-        await self.load_cogs()
 
     async def load_cogs(self) -> None:
         """Load cogs."""

--- a/src/byte/plugins/events.py
+++ b/src/byte/plugins/events.py
@@ -1,5 +1,6 @@
 """Plugins for events."""
 from threading import Thread
+from typing import cast
 
 from discord import Embed
 from discord.ext.commands import Bot, Cog
@@ -33,7 +34,10 @@ class Events(Cog):
             embed.add_field(
                 name="No Response?", value="If no response in a reasonable time, ping @Member.", inline=True
             )
-            embed.add_field(name="Closing", value=f"To close, type `{self.bot.command_prefix}solve`.", inline=True)
+            commands_to_solve = " or ".join(
+                f"`{command_prefix}solve`" for command_prefix in cast(list[str], self.bot.command_prefix)
+            )
+            embed.add_field(name="Closing", value=f"To close, type {commands_to_solve}.", inline=True)
             embed.add_field(name="MCVE", value=f"Please include an [MCVE](<{mcve}>) if relevant.", inline=False)
             embed.set_thumbnail(url=litestar_logo_yellow)
             view = HelpThreadView(author=thread.owner, bot=self.bot)


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Bytes's contribution guidelines](https://github.com/JacobCoffee/byte/blob/main/CONTRIBUTING.rst)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- Resolve hybrid commands not displaying slash commands
- Fixes the display message from "To close, type `['!', 'byte ']solve`." to "To close, type `!solve` or `byte solve`."

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

