### PR TITLE
fix: make list an enum instead of raw str field

### DIFF
--- a/byte_bot/server/domain/guilds/controllers.py
+++ b/byte_bot/server/domain/guilds/controllers.py
@@ -119,7 +119,7 @@ class GuildsController(Controller):
             title="Guild ID",
             description="The guild ID.",
         ),
-        setting: UpdateableGuildSettingEnum = Parameter(
+        setting: UpdateableGuildSettingEnum = Parameter(  # type: ignore[valid-type]
             title="Setting",
             description="The setting to update.",
         ),

--- a/byte_bot/server/domain/guilds/schemas.py
+++ b/byte_bot/server/domain/guilds/schemas.py
@@ -177,7 +177,7 @@ class UpdateableGuildSetting(CamelizedBaseModel):
 
 
 # idk
-UpdateableGuildSettingEnum = Enum(
-    "UpdateableGuildSettingEnum", 
-    {field_name.upper(): field_name for field_name in UpdateableGuildSetting.model_fields.keys()}
+UpdateableGuildSettingEnum = Enum(  # type: ignore[misc]
+    "UpdateableGuildSettingEnum",
+    {field_name.upper(): field_name for field_name in UpdateableGuildSetting.model_fields},
 )


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Bytes's contribution guidelines](https://github.com/JacobCoffee/byte/blob/main/CONTRIBUTING.rst)"

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- make the API UI dropdown and be constrained to enum available options when sending PATCH requests instead of a freeform str field

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-

## Summary by Sourcery

Constrain guild update endpoint to accept only predefined settings by introducing an enum for updateable guild fields and adjust the update call to use the enum’s value.

Enhancements:
- Introduce UpdateableGuildSettingEnum generated from UpdateableGuildSetting model fields
- Change the update_guild endpoint’s setting parameter to use the new enum instead of a raw string
- Use setting.value when passing the updated field to the guilds_service.update call