### PR TITLE
feat: implement smart text chunking for embed fields

### DIFF
--- a/services/bot/src/byte_bot/lib/utils.py
+++ b/services/bot/src/byte_bot/lib/utils.py
@@ -200,11 +200,18 @@ def smart_chunk_text(text: str, max_size: int = 1000) -> list[str]:
 
     Args:
         text: The text to chunk.
-        max_size: Maximum characters per chunk.
+        max_size: Maximum characters per chunk (must be > 0).
 
     Returns:
         List of text chunks.
+
+    Raises:
+        ValueError: If max_size is not positive.
     """
+    if max_size <= 0:
+        msg = f"max_size must be positive, got {max_size}"
+        raise ValueError(msg)
+
     if not text:
         return []
 

--- a/services/bot/src/byte_bot/plugins/astral.py
+++ b/services/bot/src/byte_bot/plugins/astral.py
@@ -11,7 +11,7 @@ from discord.ext.commands import Bot, Cog
 
 from byte_bot.lib.common.assets import ruff_logo
 from byte_bot.lib.common.colors import astral_purple, astral_yellow
-from byte_bot.lib.utils import chunk_sequence, format_ruff_rule, query_all_ruff_rules
+from byte_bot.lib.utils import format_ruff_rule, query_all_ruff_rules, smart_chunk_text
 from byte_bot.views.astral import RuffView
 
 if TYPE_CHECKING:
@@ -69,9 +69,8 @@ class Astral(Cog):
         embed = Embed(title=f"Ruff Rule: {formatted_rule_details['name']}", color=astral_yellow)
         embed.add_field(name="Summary", value=formatted_rule_details["summary"], inline=False)
 
-        # TODO: Better chunking
-        for idx, chunk in enumerate(chunk_sequence(formatted_rule_details["explanation"], 1000)):
-            embed.add_field(name="" if idx else "Explanation", value="".join(chunk), inline=False)
+        for idx, chunk in enumerate(smart_chunk_text(formatted_rule_details["explanation"], 1000)):
+            embed.add_field(name="" if idx else "Explanation", value=chunk, inline=False)
 
         embed.add_field(name="Fix", value=formatted_rule_details["fix"], inline=False)
         embed.add_field(name="Documentation", value=docs_field, inline=False)

--- a/tests/unit/bot/lib/test_utils.py
+++ b/tests/unit/bot/lib/test_utils.py
@@ -21,6 +21,7 @@ from byte_bot.lib.utils import (
     query_all_peps,
     query_all_ruff_rules,
     run_ruff_format,
+    smart_chunk_text,
 )
 
 
@@ -952,3 +953,144 @@ class TestGetNextFriday:
 
         # Should be same Friday
         assert start_dt_no_delay.day == start_dt_zero_delay.day
+
+
+class TestSmartChunkText:
+    """Tests for smart_chunk_text function."""
+
+    def test_empty_text(self) -> None:
+        """Test with empty text."""
+        result = smart_chunk_text("")
+        assert result == []
+
+    def test_text_within_limit(self) -> None:
+        """Test text that fits within max_size."""
+        text = "Short text"
+        result = smart_chunk_text(text, 100)
+        assert result == ["Short text"]
+
+    def test_splits_at_paragraph_boundary(self) -> None:
+        """Test that splitting prefers paragraph boundaries."""
+        text = "First paragraph.\n\nSecond paragraph."
+        result = smart_chunk_text(text, 25)
+        assert len(result) == 2
+        assert result[0] == "First paragraph."
+        assert result[1] == "Second paragraph."
+
+    def test_splits_at_sentence_boundary(self) -> None:
+        """Test that splitting falls back to sentence boundaries."""
+        text = "First sentence. Second sentence. Third sentence."
+        result = smart_chunk_text(text, 35)
+        assert len(result) >= 2
+        assert all(len(chunk) <= 35 for chunk in result)
+        assert "First sentence." in result[0]
+
+    def test_splits_at_newline(self) -> None:
+        """Test that splitting falls back to newlines."""
+        text = "Line one\nLine two\nLine three"
+        result = smart_chunk_text(text, 15)
+        assert len(result) >= 2
+        assert all(len(chunk) <= 15 for chunk in result)
+
+    def test_splits_at_word_boundary(self) -> None:
+        """Test that splitting falls back to word boundaries."""
+        text = "word1 word2 word3 word4 word5"
+        result = smart_chunk_text(text, 12)
+        assert len(result) >= 2
+        assert all(len(chunk) <= 12 for chunk in result)
+
+    def test_preserves_markdown_links(self) -> None:
+        """Test that markdown links are not broken when they fit within max_size."""
+        text = (
+            "First paragraph with some text here.\n\n"
+            "Check [this link](https://example.com/path) for more info.\n\n"
+            "Third paragraph with more content."
+        )
+        result = smart_chunk_text(text, 80)
+        for chunk in result:
+            if "[this link]" in chunk:
+                assert "[this link](https://example.com/path)" in chunk
+                break
+        else:
+            combined = " ".join(result)
+            assert "[this link](https://example.com/path)" in combined
+
+    def test_preserves_inline_code(self) -> None:
+        """Test that inline code is not broken when it fits within max_size."""
+        text = "First sentence here.\n\nUse the `my_function()` method here.\n\nMore text follows."
+        result = smart_chunk_text(text, 50)
+        for chunk in result:
+            if "`my_function()`" in chunk:
+                break
+        else:
+            combined = " ".join(result)
+            assert "`my_function()`" in combined
+
+    def test_preserves_code_blocks(self) -> None:
+        """Test that code blocks are not broken when they fit within max_size."""
+        text = "Example:\n\n```python\ndef foo():\n    pass\n```\n\nEnd of content."
+        result = smart_chunk_text(text, 60)
+        combined = "".join(result)
+        assert "```python" in combined
+        assert "def foo():" in combined
+        assert "```" in combined
+
+    def test_chunks_do_not_exceed_max_size(self) -> None:
+        """Test that all chunks respect max_size limit."""
+        text = "A" * 500 + " " + "B" * 500 + " " + "C" * 500
+        result = smart_chunk_text(text, 600)
+        for chunk in result:
+            assert len(chunk) <= 600
+
+    def test_multiple_markdown_links(self) -> None:
+        """Test with multiple markdown links."""
+        text = (
+            "See [link1](https://example.com/1) and [link2](https://example.com/2) "
+            "for more details on [link3](https://example.com/3)."
+        )
+        result = smart_chunk_text(text, 60)
+        combined = " ".join(result)
+        assert "[link1](https://example.com/1)" in combined
+        assert "[link2](https://example.com/2)" in combined
+        assert "[link3](https://example.com/3)" in combined
+
+    def test_mixed_protected_regions(self) -> None:
+        """Test with mixed markdown links and code."""
+        text = "Use `code` and check [docs](https://docs.example.com) for help."
+        result = smart_chunk_text(text, 40)
+        combined = " ".join(result)
+        assert "`code`" in combined
+        assert "[docs](https://docs.example.com)" in combined
+
+    def test_long_code_block_preserved(self) -> None:
+        """Test that long code blocks spanning multiple lines are preserved."""
+        code_block = "```\nline1\nline2\nline3\nline4\n```"
+        text = f"Before\n\n{code_block}\n\nAfter"
+        result = smart_chunk_text(text, 50)
+        combined = "".join(result)
+        assert code_block in combined
+
+    def test_default_max_size(self) -> None:
+        """Test that default max_size is 1000."""
+        text = "A" * 1500
+        result = smart_chunk_text(text)
+        assert len(result) >= 2
+        assert len(result[0]) <= 1000
+
+    def test_real_world_ruff_explanation(self) -> None:
+        """Test with content similar to ruff rule explanations."""
+        text = (
+            "**Why is this bad?**\n\n"
+            "Long lines make code hard to read. See [PEP 8](https://pep8.org) for guidelines.\n\n"
+            "**Example**\n\n"
+            "```python\n"
+            "x = 'very long string'\n"
+            "```\n\n"
+            "**Fix**\n\n"
+            "Break the line using parentheses."
+        )
+        result = smart_chunk_text(text, 100)
+        combined = "".join(result)
+        assert "[PEP 8](https://pep8.org)" in combined
+        assert "```python" in combined
+        assert "```" in combined


### PR DESCRIPTION
## Summary
- Resolves #75 - Don't break markdown links in Ruff output
- Adds `smart_chunk_text()` function that respects markdown structures

## Changes
- **New function**: `smart_chunk_text(text, max_size=1000)` in `services/bot/src/byte_bot/lib/utils.py`
  - Preserves markdown links `[text](url)`
  - Preserves inline code `` `code` ``
  - Preserves code blocks ` ```code``` `
  - Prefers split points: paragraphs > sentences > newlines > spaces
- **Updated**: `/ruff` command now uses `smart_chunk_text` instead of naive `chunk_sequence`
- **Added**: 15 comprehensive tests

## Test plan
- [x] Markdown links are not broken mid-chunk
- [x] Code blocks are not broken
- [x] Inline code is not broken
- [x] Chunks don't exceed max_size
- [x] All 1140 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add smart markdown-aware text chunking for Ruff rule explanations and wire it into the Astral /ruff command.

New Features:
- Introduce smart_chunk_text utility to split text into size-limited chunks while preserving markdown links, inline code, and code blocks.

Enhancements:
- Update Ruff rule embed generation to use smart markdown-aware chunking instead of generic sequence chunking for explanations.

Tests:
- Add comprehensive unit tests covering smart_chunk_text behavior, including markdown preservation, boundary preferences, and size limits.